### PR TITLE
Update Portainer.md - invalid link

### DIFF
--- a/manuscript/recipes/portainer.md
+++ b/manuscript/recipes/portainer.md
@@ -12,7 +12,7 @@ This is a "lightweight" recipe, because Portainer is so "lightweight". But it **
 
 1. [Docker swarm cluster](/ha-docker-swarm/design/) with [persistent shared storage](/ha-docker-swarm/shared-storage-ceph.md)
 2. [Traefik](/ha-docker-swarm/traefik) configured per design
-3. DNS entry for the hostname you intend to use, pointed to your [keepalived](ha-docker-swarm/keepalived/) IP
+3. DNS entry for the hostname you intend to use, pointed to your [keepalived](/ha-docker-swarm/keepalived/) IP
 
 ## Preparation
 


### PR DESCRIPTION
On the recipe page for portainer, the link for keepalived points to https://geek-cookbook.funkypenguin.co.nz/recipes/portainer/ha-docker-swarm/keepalived/
Correct page is https://geek-cookbook.funkypenguin.co.nz/ha-docker-swarm/keepalived/