### PR TITLE
Improve Kanboard mounts

### DIFF
--- a/manuscript/recipes/kanboard.md
+++ b/manuscript/recipes/kanboard.md
@@ -65,8 +65,7 @@ services:
   kanboard:
     image: kanboard/kanboard
     volumes:
-     - /var/data/kanboard/data:/var/www/app/data
-     - /var/data/kanboard/plugins:/var/www/app/plugins
+     - /var/data/kanboard:/var/www/app/
     networks:
     - internal
     deploy:


### PR DESCRIPTION
Having each folder listed as volumes individually causes issues. "Invalid mount config" in "docker stack ps kanboard"