### PR TITLE
Addition of Traefik Forward Authentication sub-recipes for Autopirate Stack

### DIFF
--- a/manuscript/recipes/autopirate/headphones.md
+++ b/manuscript/recipes/autopirate/headphones.md
@@ -46,6 +46,27 @@ headphones_proxy:
     -authenticated-emails-file=/authenticated-emails.txt
 ````
 
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+headphones:
+  image: linuxserver/headphones:latest
+  env_file : /var/data/config/autopirate/headphones.env
+  volumes:
+   - /var/data/autopirate/headphones:/config
+   - /var/data/media:/media
+  networks:
+  - internal
+    - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:headphones.example.com
+      - traefik.port=8181
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
+
 !!! tip
     I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍
 

--- a/manuscript/recipes/autopirate/heimdall.md
+++ b/manuscript/recipes/autopirate/heimdall.md
@@ -47,10 +47,28 @@ To include Heimdall in your [AutoPirate](/recipes/autopirate/) stack, include th
       -email-domain=example.com
       -provider=github
       -authenticated-emails-file=/authenticated-emails.txt
-
-
-
 ```
+
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+```
+  heimdall:
+    image: linuxserver/heimdall:latest
+    env_file: /var/data/config/autopirate/heimdall.env
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /var/data/heimdall:/config
+    networks:
+      - internal
+      - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:heimdall.example.com
+      - traefik.port=80
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ```
 
 !!! tip
 I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a `git pull` and a `docker stack deploy` 👍

--- a/manuscript/recipes/autopirate/jackett.md
+++ b/manuscript/recipes/autopirate/jackett.md
@@ -45,7 +45,25 @@ jackett_proxy:
     -authenticated-emails-file=/authenticated-emails.txt
 
 ```
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+```
+jackett:
+  image: linuxserver/jackett:latest
+  env_file : /var/data/config/autopirate/jackett.env
+  volumes:
+   - /var/data/autopirate/jackett:/config
+  networks:
+  - internal
+    - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:jackett.example.com
+      - traefik.port=9117
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ```
 !!! tip
 I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a `git pull` and a `docker stack deploy` 👍
 

--- a/manuscript/recipes/autopirate/lazylibrarian.md
+++ b/manuscript/recipes/autopirate/lazylibrarian.md
@@ -57,7 +57,33 @@ calibre-server:
   - internal    
 
 ````
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+lazylibrarian:
+  image: linuxserver/lazylibrarian:latest
+  env_file : /var/data/config/autopirate/lazylibrarian.env
+  volumes:
+   - /var/data/autopirate/lazylibrarian:/config
+   - /var/data/media:/media
+  networks:
+  - internal
+  - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:ombi.example.com
+      - traefik.port=5299
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+calibre-server:
+  image: regueiro/calibre-server
+  volumes:
+   - /var/data/media/Ebooks/calibre/:/opt/calibre/library
+  networks:
+  - internal
+  ````
+  
 !!! tip
     I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍
 

--- a/manuscript/recipes/autopirate/lidarr.md
+++ b/manuscript/recipes/autopirate/lidarr.md
@@ -45,7 +45,26 @@ lidarr_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ````
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+lidarr:
+  image: linuxserver/lidarr:latest
+  env_file : /var/data/config/autopirate/lidarr.env
+  volumes:
+   - /var/data/autopirate/lidarr:/config
+   - /var/data/media:/media
+  networks:
+  - internal
+    - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:lidarr.example.com
+      - traefik.port=8181
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
 !!! tip
     I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍
 

--- a/manuscript/recipes/autopirate/mylar.md
+++ b/manuscript/recipes/autopirate/mylar.md
@@ -43,7 +43,26 @@ mylar_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ````
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+mylar:
+  image: linuxserver/mylar3:latest
+  env_file : /var/data/config/autopirate/mylar.env
+  volumes:
+   - /var/data/autopirate/mylar:/config
+   - /var/data/media:/media
+  networks:
+  - internal
+  - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:mylar.example.com
+      - traefik.port=8090
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
 !!! tip
     I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍
 

--- a/manuscript/recipes/autopirate/nzbget.md
+++ b/manuscript/recipes/autopirate/nzbget.md
@@ -49,7 +49,26 @@ nzbget_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ````
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+nzbget:
+  image: linuxserver/nzbget
+  env_file : /var/data/config/autopirate/nzbget.env  
+  volumes:
+   - /var/data/autopirate/nzbget:/config
+   - /var/data/media:/data
+  networks:
+  - internal
+  - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:ombi.example.com
+      - traefik.port=6789
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
 !!! note
     NZBGet uses a 401 header to prompt for authentication. When you use OAuth2_proxy, this seems to break. Since we trust OAuth to authenticate us, we can just disable NZGet's own authentication, by changing ControlPassword to null in nzbget.conf (i.e. ```ControlPassword=```)
 

--- a/manuscript/recipes/autopirate/nzbhydra.md
+++ b/manuscript/recipes/autopirate/nzbhydra.md
@@ -49,7 +49,26 @@ nzbhydra_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ````
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+nzbhydra:
+  image: linuxserver/hydra:latest
+  env_file : /var/data/config/autopirate/nzbhydra.env
+  volumes:
+   - /var/data/autopirate/nzbhydra:/config
+  networks:
+  - internal
+  - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:nzbhydra.example.com
+      - traefik.port=5075
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
+  
 !!! tip
     I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍
 

--- a/manuscript/recipes/autopirate/nzbhydra2.md
+++ b/manuscript/recipes/autopirate/nzbhydra2.md
@@ -62,7 +62,25 @@ nzbhydra2_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ```
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+nzbhydra2:
+  image: linuxserver/hydra2:latest
+  env_file : /var/data/config/autopirate/nzbhydra2.env
+  volumes:
+   - /var/data/autopirate/nzbhydra2:/config
+  networks:
+  - internal
+  - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:nzbhydra2.example.com
+      - traefik.port=5076
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
 !!! tip
 I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a `git pull` and a `docker stack deploy` 👍
 

--- a/manuscript/recipes/autopirate/ombi.md
+++ b/manuscript/recipes/autopirate/ombi.md
@@ -50,6 +50,25 @@ ombi_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ````
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+ombi:
+  image: linuxserver/ombi:latest
+  env_file : /var/data/config/autopirate/ombi.env
+  volumes:
+    - /var/data/autopirate/ombi:/config
+  networks:
+    - internal
+    - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:ombi.example.com
+      - traefik.port=3579
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
 
 !!! tip
     I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍

--- a/manuscript/recipes/autopirate/radarr.md
+++ b/manuscript/recipes/autopirate/radarr.md
@@ -61,7 +61,26 @@ radarr_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ````
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+radarr:
+  image: linuxserver/radarr:latest
+  env_file : /var/data/config/autopirate/radarr.env
+  volumes:
+   - /var/data/autopirate/radarr:/config
+   - /var/data/media:/media
+  networks:
+  - internal
+    - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:radarr.example.com
+      - traefik.port=7878
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
 !!! tip
     I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍
 

--- a/manuscript/recipes/autopirate/rtorrent.md
+++ b/manuscript/recipes/autopirate/rtorrent.md
@@ -50,6 +50,31 @@ rtorrent_proxy:
     -authenticated-emails-file=/authenticated-emails.txt
 ```
 
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+rtorrent:
+  image: linuxserver/rutorrent
+  env_file : /var/data/config/autopirate/rtorrent.env
+  ports:
+   - 36258:36258
+  volumes:
+   - /var/data/media/:/media
+   - /var/data/autopirate/rtorrent:/config
+  networks:
+  - internal
+  - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:rtorrent.example.com
+      - traefik.port=80
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
+
+
+
 !!! tip
         I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍
 

--- a/manuscript/recipes/autopirate/sabnzbd.md
+++ b/manuscript/recipes/autopirate/sabnzbd.md
@@ -52,6 +52,26 @@ sabnzbd_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ````
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+sabnzbd:
+  image: linuxserver/sabnzbd:latest
+  env_file : /var/data/config/autopirate/sabnzbd.env  
+  volumes:
+   - /var/data/autopirate/sabnzbd:/config
+   - /var/data/media:/media
+  networks:
+  - internal
+  - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:ombi.example.com
+      - traefik.port=8080
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
 
 !!! warning "Important Note re hostname validation"
 

--- a/manuscript/recipes/autopirate/sonarr.md
+++ b/manuscript/recipes/autopirate/sonarr.md
@@ -47,7 +47,26 @@ sonarr_proxy:
     -provider=github
     -authenticated-emails-file=/authenticated-emails.txt
 ````
-
+## To use [Traefik Forward Authentication (TFA)](/ha-docker-swarm/traefik-forward-auth/):
+````
+sonarr:
+  image: linuxserver/sonarr:latest
+  env_file : /var/data/config/autopirate/sonarr.env
+  volumes:
+   - /var/data/autopirate/sonarr:/config
+   - /var/data/media:/media
+  networks:
+  - internal
+  - traefik_public
+  deploy:
+    labels:
+      - traefik.frontend.rule=Host:sonarr.example.com
+      - traefik.port=8989
+      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
+      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
+      - traefik.frontend.auth.forward.trustForwardHeader=true
+      - traefik.docker.network=traefik_public
+  ````
 !!! tip
     I share (_with my [sponsors](https://github.com/sponsors/funkypenguin)_) a private "_premix_" git repository, which includes necessary docker-compose and env files for all published recipes. This means that sponsors can launch any recipe with just a ```git pull``` and a ```docker stack deploy``` 👍
 


### PR DESCRIPTION
Added a basic sub-recipe to each service to add detail on utilizing TFA

## Description
Added the template of:
```
ombi:
  image: linuxserver/ombi:latest
  env_file : /var/data/config/autopirate/ombi.env
  volumes:
    - /var/data/autopirate/ombi:/config
  networks:
    - internal
    - traefik_public
  deploy:
    labels:
      - traefik.frontend.rule=Host:ombi.example.com
      - traefik.port=3579
      - traefik.frontend.auth.foreard.address=http://traefik-forward-auth:4181
      - traefik.frontend.auth.forward.authResponseHeaders=X-Forwarded-User
      - traefik.frontend.auth.forward.trustForwardHeader=true
      - traefik.docker.network=traefik_public
```

## Motivation and Context
I had serious issues setting up my stack to use TFA instead of OAuth2_Proxy.
This will hopefully solve the problem for future users of the guide in the same situation.

## How Has This Been Tested?
Currently running on my swarm

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
