### PR TITLE
Remove unnecessary .env file from linx recipe

### DIFF
--- a/manuscript/recipes/linx.md
+++ b/manuscript/recipes/linx.md
@@ -50,7 +50,6 @@ version: "3.2" # https://docs.docker.com/compose/compose-file/compose-versioning
 services:
   linx:
     image: andreimarcu/linx-server
-    env_file: /var/data/config/linx/linx.env
     command: -config /linx.conf
     volumes:
       - /var/data/linx/:/files/


### PR DESCRIPTION
Removed linx.env reference from the docker-compose.yml as it was unneeded and caused an error on deployment