### PR TITLE
Add `enablePasswordDB: true` for Dex

### DIFF
--- a/manuscript/ha-docker-swarm/traefik-forward-auth/dex-static.md
+++ b/manuscript/ha-docker-swarm/traefik-forward-auth/dex-static.md
@@ -35,6 +35,8 @@ staticClients:
   name: 'example.com'
   secret: bar
 
+enablePasswordDB: true
+
 staticPasswords:
 - email: "admin@example.com"
   # bcrypt hash of the string "password"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above ^^^ -->

## Description
enablePasswordDB should be true when using staticPasswords, or else an error is thrown:



## Motivation and Context
> cannot specify static passwords without enabling password db

See [config.go](https://github.com/dexidp/dex/blob/2211c515a699cfe73f79eaf4cce0a231234bb7e1/cmd/dex/config.go#L62).

## How Has This Been Tested?
By running Dex with this config

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [ ] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [ ] I've added at least one footnote to my recipe (*Chef's Notes*)