### PR TITLE
Correct Environment Variables for db-backup

### DIFF
--- a/manuscript/recipes/paperless-ng.md
+++ b/manuscript/recipes/paperless-ng.md
@@ -130,9 +130,10 @@ services:
       - /var/data/paperless/database-dump:/dump
       - /etc/localtime:/etc/localtime:ro
     environment:
-      POSTGRES_DB: paperless
-      POSTGRES_USER: paperless
-      POSTGRES_PASSWORD: paperless
+      PGHOST: db
+      PGDATABASE: paperless
+      PGUSER: paperless
+      PGPASSWORD: paperless
       BACKUP_NUM_KEEP: 7
       BACKUP_FREQUENCY: 1d
     entrypoint: |


### PR DESCRIPTION
## Description
The DB backup was failing for me. It appears that pg_dump from Postgres 13 uses different environment variables than those that were included in the recipe. I have added PGHOST to identify the container running the database to backup, and renamed the POSTGRES_* items to PG* which matches https://www.postgresql.org/docs/13/app-pgdump.html.

## Motivation and Context
It enables successful backups of the paperless-ng db

## How Has This Been Tested?
Test restored the backed up DB file back into a new database within postgres, and was able to see content. I didn't try to start a new paperless-ng instance however with this restored DB.

## Screenshots (if appropriate):

## Types of changes
<!-- ignore-task-list-start -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist
- [X] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [X] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [X] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.
