### PR TITLE
Update to the authelia recipe

### DIFF
--- a/manuscript/ha-docker-swarm/authelia.md
+++ b/manuscript/ha-docker-swarm/authelia.md
@@ -40,9 +40,12 @@ Authelia configurations are defined in `/var/data/config/authelia/configuration.
 #                   Authelia configuration                    #
 ###############################################################
 
-host: 0.0.0.0
-port: 9091
-log_level: warn
+server:
+  host: 0.0.0.0
+  port: 9091
+
+log:
+  level: warn
 
 # This secret can also be set using the env variables AUTHELIA_JWT_SECRET_FILE
 # I used this site to generate the secret: https://www.grc.com/passwords.htm
@@ -92,6 +95,7 @@ regulation:
   ban_time: 300
 
 storage:
+  encryption_key: SECRET_GOES_HERE
   local:
     path: /config/db.sqlite3
 
@@ -188,7 +192,7 @@ services:
         - "traefik.http.routers.whoami.rule=Host(`whoami.example.com`)"
         - "traefik.http.routers.whoami.entrypoints=https"
         - "traefik.http.services.whoami.loadbalancer.server.port=80"
-        - "traefik.http.routers.service.middlewares=forward-auth@file"
+        - "traefik.http.routers.whoami.middlewares=forward-auth@file"
 
 
 networks:


### PR DESCRIPTION
Updated the configuration file for anthelia (config changed with a newer version) and fixed a bug in the whomami traefik labels that would prevent the right service from being created.

<!-- Provide a general summary of your changes in the Title above ^^^ -->

## Description
Small configuration change for authelia and fixing a typo in the traefik labels for whoami.

## Motivation and Context
With the current recipe authelia isn't starting (crashes on start complaining about a missing encryption key for storage configuration). 

Whoami is not registering correctly with traefik and will not be protected by authelia.

## How Has This Been Tested?
Updated configuration and docker-compose file and run on my home server setup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- ignore-task-list-start -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [X] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [ ] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.