### PR TITLE
Add closing ' mark to 'dsd' and 'dsr' aliases

### DIFF
--- a/examples/scripts/gcb-aliases.sh
+++ b/examples/scripts/gcb-aliases.sh
@@ -1,6 +1,6 @@
 alias dklc='docker ps -l'  # List last Docker container
 alias dklcid='docker ps -l -q'  # List last Docker container ID
-alias dklcip='docker inspect -f "{{.NetworkSettings.IPAddress}}" $(docker ps -l -q)'  # Get IP of last Docker container
+alias dklcip='docker inspect -f "{{range .NetworkSettings.Networks}}{{println .IPAddress}}{{end}}" $(docker ps -l -q)'  # Get IP's of last Docker container
 alias dkps='docker ps'  # List running Docker containers
 alias dkpsa='docker ps -a'  # List all Docker containers
 alias dki='docker images'  # List Docker images
@@ -14,5 +14,5 @@ alias dkideps='docker-image-dependencies'  # Output a graph of image dependencie
 alias dkre='docker-runtime-environment'  # List environmental variables of the supplied image ID
 alias dkelc='docker exec -it `dklcid` bash' # Enter last container (works with Docker 1.3 and above)
 alias git='docker run -v $PWD:/var/data -v /var/data/git-docker/data/.ssh:/root/.ssh funkypenguin/git-docker git' # Run git client in a container (for hosts witohut git)
-alias dsd='docker stack deploy "$1" -c /var/data/config/"$1"/"$1".yml
-alias dsr='docker stack rm "$1"
+alias dsd='docker stack deploy "$1" -c /var/data/config/"$1"/"$1".yml'
+alias dsr='docker stack rm "$1"'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above ^^^ -->

## Description
<!--- Describe your changes in detail -->
- Updated the "dklcip" alias to list all IP's in a container, if it is connected to multiple Networks.
- Added necessary ' at end of alias command for "dsd" and "dsr" aliases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- The "dklcip" alias no longer worked, as the GO template headers seem to have been changed.
- The closing ' is required when creating an alias with " in the aliased command.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Ran many iterations of the "dklcip" command --format options to verify it now works as described.
- Place the "dsd" and "dsr" alias lines with additional code after them, and note the added ' correctly closes out the alias command.
```
Docker version 20.10.7-qnap3, build 50b64c4
docker-compose version 1.29.2, build 392a2ab7
```
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- ignore-task-list-start -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.
