### PR TITLE
Fix Traefik Forward Auth 404ing

### DIFF
--- a/_snippets/recipe-standard-ingredients.md
+++ b/_snippets/recipe-standard-ingredients.md
@@ -9,4 +9,4 @@
 
     Related:
 
-    * [X] [Traefik Forward Auth](ha-docker-swarm/traefik-forward-auth/) to secure your Traefik-exposed services with an additional layer of authentication
+    * [X] [Traefik Forward Auth](/ha-docker-swarm/traefik-forward-auth/) to secure your Traefik-exposed services with an additional layer of authentication


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above ^^^ -->

## Description
At the moment Traefik Forward auth in ingredients will 404 when clicked on

## Types of changes
<!-- ignore-task-list-start -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [x] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.