### PR TITLE
Fix rook-ceph namespace mismatch

### DIFF
--- a/docs/kubernetes/persistence/rook-ceph/operator.md
+++ b/docs/kubernetes/persistence/rook-ceph/operator.md
@@ -24,13 +24,13 @@ To start off with, we need to deploy the ceph operator into the cluster, after w
 
 ### Namespace
 
-We need a namespace to deploy our HelmRelease and associated ConfigMaps into. Per the [flux design](/kubernetes/deployment/flux/), I create this example yaml in my flux repo at `/bootstrap/namespaces/namespace-rook-system.yaml`:
+We need a namespace to deploy our HelmRelease and associated ConfigMaps into. Per the [flux design](/kubernetes/deployment/flux/), I create this example yaml in my flux repo at `/bootstrap/namespaces/namespace-rook-ceph.yaml`:
 
 ```yaml title="/bootstrap/namespaces/namespace-rook-ceph.yaml"
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rook-system
+  name: rook-ceph
 ```
 
 ### HelmRepository


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above ^^^ -->

## Description
Updated the creation of the rook ceph namespace as there was a discrepancy between rook-ceph and rook-system

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- ignore-task-list-start -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [x] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.