### PR TITLE
Avoid local image building for local dev

### DIFF
--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -59,7 +59,7 @@ The process is basically:
 1. [Fork the repo](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
 2. Clone your forked repo locally
 3. Make a new branch for your recipe (*not strictly necessary, but it helps to differentiate multiple in-flight recipes*)
-4. Create your new recipe as a markdown file within the existing structure of the [docs folder](https://github.com/geek-cookbook/geek-cookbook/tree/main/docs)
+4. Create your new recipe as a markdown file within the existing structure of the [docs folder](https://github.com/geek-cookbook/geek-cookbook/tree/main/docs) (see `docs/recipes/template.md` and `doc/recipes/kubernetes/template.md` for examples)
 5. Add your recipe to the navigation by editing [mkdocs.yml](https://github.com/geek-cookbook/geek-cookbook/blob/main/mkdocs.yml#L32)
 6. Test locally by running `./scripts/serve.sh` in the repo folder (*this launches a preview in Docker*), and navigating to <http://localhost:8123>
 7. Rinse and repeat until you're ready to submit a PR

--- a/mkdocs-insiders.yml
+++ b/mkdocs-insiders.yml
@@ -2,6 +2,7 @@
 # that don't degrade for the open-source version
 INHERIT: mkdocs.yml
 plugins:
+  extra-sass:  
   meta:
   blog:
     # post_excerpt: required
@@ -33,3 +34,37 @@ plugins:
       - shields.io/*      
   optimize:
     enabled: false # seems to break netlify builds :(
+  with-pdf:
+    #author: David Young
+    #copyright: ANY TEXT
+    # cover: true
+    back_cover: true
+    #cover_title: TITLE TEXT
+    #cover_subtitle: SUBTITLE TEXT
+    # cover_logo: images/cover_logo.png
+    custom_template_path: with_pdf_template
+    #toc_title: TOC TITLE TEXT
+    #heading_shift: true
+    toc_level: 3
+    ordered_chapter_level: 4
+    excludes_children:
+        - '*/:discourse-comments'
+        - '*/:employ-your-chef-engage'
+        - '*/:flirt-with-waiter-subscribe'
+        - '*/:fn:1'
+    exclude_pages:
+        - 'reference/oauth_proxy/'
+        - 'appendix/contribute/'
+    convert_iframe:
+        - src: IFRAME SRC
+          img: POSTER IMAGE URL
+          text: ALTERNATE TEXT
+        - src: ...
+#    two_columns_level: 3
+    render_js: false
+    # headless_chrome_path: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+    output_path: funkypenguins-geek-cookbook.pdf
+    debug_html: false
+    show_anchors: true
+    verbose: false
+    enabled_if_env: ENABLE_PDF_EXPORT

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,51 +16,16 @@ copyright: 'Copyright &copy; 2016 - 2023 David Young, Funky Penguin Limited'
 
 # Plugins
 plugins:
-  extra-sass:
   search:
   minify:
     minify_html: true
+  autolinks:
   git-revision-date-localized:
     type: date
-    fallback_to_build_date: true
-  autolinks:
+    fallback_to_build_date: true  
   macros:
     verbose: true
   meta-descriptions: # If not provided, auto-generate a description (https://pypi.org/project/mkdocs-meta-descriptions-plugin/)
-  with-pdf:
-    #author: David Young
-    #copyright: ANY TEXT
-    # cover: true
-    back_cover: true
-    #cover_title: TITLE TEXT
-    #cover_subtitle: SUBTITLE TEXT
-    # cover_logo: images/cover_logo.png
-    custom_template_path: with_pdf_template
-    #toc_title: TOC TITLE TEXT
-    #heading_shift: true
-    toc_level: 3
-    ordered_chapter_level: 4
-    excludes_children:
-        - '*/:discourse-comments'
-        - '*/:employ-your-chef-engage'
-        - '*/:flirt-with-waiter-subscribe'
-        - '*/:fn:1'
-    exclude_pages:
-        - 'reference/oauth_proxy/'
-        - 'appendix/contribute/'
-    convert_iframe:
-        - src: IFRAME SRC
-          img: POSTER IMAGE URL
-          text: ALTERNATE TEXT
-        - src: ...
-#    two_columns_level: 3
-    render_js: false
-    # headless_chrome_path: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
-    output_path: funkypenguins-geek-cookbook.pdf
-    debug_html: false
-    show_anchors: true
-    verbose: false
-    enabled_if_env: ENABLE_PDF_EXPORT
 
 
 #theme_dir: mkdocs-material

--- a/scripts/serve-insiders.sh
+++ b/scripts/serve-insiders.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # docker pull ghcr.io/geek-cookbook/mkdocs-material-insiders
-docker build --build-arg FROM_SOURCE=ghcr.io/geek-cookbook/mkdocs-material-insiders . -t funkypenguin/mkdocs-material
-docker run --rm --name mkdocs-material -it -p 8123:8000 -v ${PWD}:/docs -e PROD_BUILD=false funkypenguin/mkdocs-material serve \
+docker build --build-arg FROM_SOURCE=ghcr.io/geek-cookbook/mkdocs-material-insiders . -t funkypenguin/mkdocs-material-insiders
+docker run --rm --name mkdocs-material -it -p 8123:8000 -v ${PWD}:/docs -e PROD_BUILD=false funkypenguin/mkdocs-material-insiders serve \
     --dev-addr 0.0.0.0:8000 \
     --dirtyreload \
     --config-file mkdocs-insiders.yml

--- a/scripts/serve-insiders.sh
+++ b/scripts/serve-insiders.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # docker pull ghcr.io/geek-cookbook/mkdocs-material-insiders
 docker build --build-arg FROM_SOURCE=ghcr.io/geek-cookbook/mkdocs-material-insiders . -t funkypenguin/mkdocs-material
-docker run --rm --name mkdocs-material -it -p 8123:8000 -v ${PWD}:/docs funkypenguin/mkdocs-material serve -f mkdocs-insiders.yml --dev-addr 0.0.0.0:8000 --dirtyreload
+docker run --rm --name mkdocs-material -it -p 8123:8000 -v ${PWD}:/docs -e PROD_BUILD=false funkypenguin/mkdocs-material serve \
+    --dev-addr 0.0.0.0:8000 \
+    --dirtyreload \
+    --config-file mkdocs-insiders.yml

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-docker pull squidfunk/mkdocs-material:latest
-docker build . -t funkypenguin/mkdocs-material
-docker run --rm --name mkdocs-material -it -p 8123:8000 -v ${PWD}:/docs -e PROD_BUILD=false funkypenguin/mkdocs-material serve \
+# docker pull squidfunk/mkdocs-material:latest
+# docker build . -t funkypenguin/mkdocs-material
+docker run --rm --name mkdocs-material -it -p 8123:8000 -v ${PWD}:/docs -e PROD_BUILD=false ghcr.io/geek-cookbook/mkdocs-material:master serve \
     --dev-addr 0.0.0.0:8000 \
     --dirtyreload

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-#docker pull squidfunk/mkdocs-material:latest
-#docker build . -t funkypenguin/mkdocs-material
+docker pull squidfunk/mkdocs-material:latest
+docker build . -t funkypenguin/mkdocs-material
 docker run --rm --name mkdocs-material -it -p 8123:8000 -v ${PWD}:/docs -e PROD_BUILD=false funkypenguin/mkdocs-material serve \
     --dev-addr 0.0.0.0:8000 \
-    --dirtyreload \
-    --config-file mkdocs-insiders.yml
+    --dirtyreload


### PR DESCRIPTION
Signed-off-by: David Young <davidy@funkypenguin.co.nz>

<!-- Provide a general summary of your changes in the Title above ^^^ -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- ignore-task-list-start -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [ ] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [ ] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.

<!-- 
delete these next checks if not adding a new recipe 
-->
- [ ] I've added at least one footnote to my recipe (*Chef's Notes*)
- [ ] I've updated `common-links.md` in the `_snippets` directory and sorted alphabetically
- [ ] I've updated the navigation in `mkdocs.yaml` in alphabetical order
- [ ] I'm using the [oldest-possible version](https://docs.docker.com/compose/compose-file/compose-versioning/#version-3) of Docker-compose syntax for the feature my recipe needs (*v3.2 unless there's a specific need for a later version*)
- [ ] If traefik integration is required, I've included both v1 and v2 labels (*see [template](/manuscript/recipes/template.md)*)
- [ ] If a recipe-specific overlay network is required, I've used a unique subnet and recorded it in [networks.md](manuscript/reference/networks.md)
- [ ] I've considered updating `.github/CODEOWNERS` so that I'll be automatically included as a reviewer on future changes to this recipe