### PR TITLE
Added missing comma to env variable example

### DIFF
--- a/docs/recipes/kubernetes/authentik.md
+++ b/docs/recipes/kubernetes/authentik.md
@@ -80,7 +80,7 @@ If you're after a more hands-off implementation, you can also pre-set a "bootstr
 
 ```yaml hl_lines="2-3" title="Optionally pre-configure your bootstrap secrets"
     env:
-      AUTHENTIK_BOOTSTRAP_PASSWORD: "iamusedbyhumanz"
+      AUTHENTIK_BOOTSTRAP_PASSWORD: "iamusedbyhumanz",
       AUTHENTIK_BOOTSTRAP_TOKEN: "iamusedbymachinez"
 ```
 


### PR DESCRIPTION
## Description
Added a missing comma to the environment variable configuration example between the 2 values

## Motivation and Context
The helm chart fails to reconcile without the comma

## How Has This Been Tested?
Watching the kustomization successfully reconcile on my own cluster.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- ignore-task-list-start -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [X] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [ ] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.