### PR TITLE
(fix) Updated paths to csi snapshot component pages

### DIFF
--- a/docs/kubernetes/backup/csi-snapshots/index.md
+++ b/docs/kubernetes/backup/csi-snapshots/index.md
@@ -13,6 +13,6 @@ K8s-sig-storage publishes [external-snapshotter](https://github.com/kubernetes-c
 
 There are two components required in order to bring snapshot-taking powerz to your bare-metal cluster, detailed below:
 
-1. First, install the [snapshot validation webhook](/kubernetes/csi-snapshots/snapshot-validation-webhook.md/)
-2. Then, install the [snapshot controller](/kubernetes/csi-snapshots/snapshot-controller.md)
+1. First, install the [snapshot validation webhook](/kubernetes/backup/csi-snapshots/snapshot-validation-webhook.md/)
+2. Then, install the [snapshot controller](/kubernetes/backup/csi-snapshots/snapshot-controller.md)
 3. Install a snapshot-supporting :camera: [backup tool](/kubernetes/backup/) 


### PR DESCRIPTION
## Description
Added missing `backup` path component to snapshop components linked at the bottom of the page to resolve 404 errors

## Motivation and Context
Links were broken, yo (though they did work in the side nav)

## How Has This Been Tested?
YOLO

## Screenshots (if appropriate):

## Types of changes
<!-- ignore-task-list-start -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
<!-- ignore-task-list-end -->

## Checklist

- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] The format of my changes matches that of other recipes (*ideally it was copied from [template](/manuscript/recipes/template.md)*)
- [X] My changes have passed markdown linting, either by running `./scripts/local-markdownlint.sh` locally, or by checking the status of the PR check below.